### PR TITLE
Fix build when using WIN32_LEAN_AND_MEAN

### DIFF
--- a/ext/vswhom.cpp
+++ b/ext/vswhom.cpp
@@ -16,6 +16,7 @@
 #include <windows.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unknwn.h>
 #include <assert.h>
 #include <stdio.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Compilation fails when using a build system that defines WIN32_LEAN_AND_MEAN. The error is unknown type IUnknown, amongst others. The fix is to simply include the additional header.